### PR TITLE
CI fix: don't hide the copr username

### DIFF
--- a/.github/workflows/auri.yml
+++ b/.github/workflows/auri.yml
@@ -189,7 +189,7 @@ jobs:
           cat > ~/.config/copr <<EOF
           [copr-cli]
           login = ${{ secrets.COPR_LOGIN }}
-          username = ${{ secrets.COPR_USERNAME }}
+          username = auri
           token = ${{ secrets.COPR_TOKEN }}
           copr_url = https://copr.fedorainfracloud.org
           EOF


### PR DESCRIPTION
it's anyway exposed, if we hide via secrets - word 'auri' is getting masked in the CI logs everythere