### PR TITLE
Fix: customized templates

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	Environment                     string   `envyname:"ENVIRONMENT" default:"production"`
 	SessionSecret                   string   `envyname:"SESSION_SECRET"`
 	Layout                          string   `envyname:"LAYOUT" default:"application.html"`
-	WebTemplatePath                 string   `envyname:"WEB_TEMPLATE_PATH" default:"../templates"`
+	WebTemplatePath                 string   `envyname:"WEB_TEMPLATE_PATH" default:""`
 	WebAssetPath                    string   `envyname:"WEB_ASSET_PATH" default:""`
 	BaseURL                         string   `envyname:"BASE_URL"`
 	ContactEmail                    string   `envyname:"CONTACT_EMAIL"`

--- a/templates/embed.go
+++ b/templates/embed.go
@@ -1,8 +1,11 @@
 package templates
 
 import (
+	"auri/config"
+
 	"embed"
 	"io/fs"
+	"os"
 
 	"github.com/gobuffalo/buffalo"
 )
@@ -11,5 +14,10 @@ import (
 var files embed.FS
 
 func FS() fs.FS { //revive:disable-line
+	// use own templates if defined
+	if config.GetInstance().WebTemplatePath != "" {
+		return os.DirFS(config.GetInstance().WebTemplatePath)
+	}
+
 	return buffalo.NewFS(files, "templates")
 }


### PR DESCRIPTION
Own templates were broken in the migration to buffalo 0.18 because of new embed way of working with templates