### PR TITLE
Fix: broken credential reset

### DIFF
--- a/templates/credentials-reset-data-collection.plush.html
+++ b/templates/credentials-reset-data-collection.plush.html
@@ -20,7 +20,7 @@
   <%= form({action: credentialresetProcessTokenpwrCreatePath ({ tokenpwr: tokenpwr }), method: "POST"}) { %>
 
   <p>
-    <button class="btn btn-brand btn-block" type="button" data-toggle="collapse" data-target="#collapsePassword" aria-expanded="false" aria-controls="collapsePassword">
+    <button class="btn btn-brand btn-block" type="button" data-bs-toggle="collapse" data-bs-target="#collapsePassword" aria-expanded="false" aria-controls="collapsePassword">
       Set new password
     </button>
   </p>
@@ -36,7 +36,7 @@
   </div>
 
   <p>
-    <button class="btn btn-brand btn-block" type="button" data-toggle="collapse" data-target="#collapseSSHKey" aria-expanded="false" aria-controls="collapseSSHKey">
+    <button class="btn btn-brand btn-block" type="button" data-bs-toggle="collapse" data-bs-target="#collapseSSHKey" aria-expanded="false" aria-controls="collapseSSHKey">
       Set new SSH key
     </button>
   </p>


### PR DESCRIPTION
because of new field identifiers in bootstrap 5

Fixes: https://github.com/auri/auri/issues/41